### PR TITLE
imageUtilKernels.cu: optimize initAttentionMaskKernel

### DIFF
--- a/cpp/kernels/preprocessKernels/imageUtilKernels.cu
+++ b/cpp/kernels/preprocessKernels/imageUtilKernels.cu
@@ -432,11 +432,11 @@ __global__ void initAttentionMaskKernel(
     auto const start = cuSeqlens[bIdx];
     auto const end = cuSeqlens[bIdx + 1];
     auto const tIdx = threadIdx.x;
-    auto const tidy = threadIdx.y;
+    auto const tIdy = threadIdx.y;
 
-    for (auto i = start + tIdx; i < end; i += 16)
+    for (auto i = start + tIdy; i < end; i += 16)
     {
-        for (auto j = start + tidy; j < end; j += 16)
+        for (auto j = start + tIdx; j < end; j += 16)
         {
             auto const posIdx = i * curHW + j;
             attentionMask[posIdx] = __float2half(0.0f);


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Optimization

**Overview:** 
Simply change the loop order in `imageUtilKernels.cu:initAttentionMaskKernel`. Take Qwen2.5-VL as example, optimize the kernel from 2.8ms to 0.4ms for 640*640 image input.
Before
<img width="222" height="364" alt="image" src="https://github.com/user-attachments/assets/c97b37ca-83ad-488c-8676-14ab1cb7e508" />

After
<img width="222" height="364" alt="image" src="https://github.com/user-attachments/assets/f2378f27-1e4e-420f-8503-dc3c9f9c39a5" />

## Testing
Just use nsys to profile it and you can see it.


- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Just reuse previous test
- **Did you add or update any necessary documentation?**: No need to do that
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CHANGELOG.md)?**: No
