### PR TITLE
chore: Implement FindTensorRT module with component support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,32 +120,15 @@ else()
   set(NVTX_INCLUDE_DIR "")
 endif()
 
-# Set TensorRT header includes and library dependencies.
-if(NOT DEFINED TRT_PACKAGE_DIR)
-  message(
-    FATAL_ERROR "Please specify the -DTRT_PACKAGE_DIR when invoking CMake.")
-endif()
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-find_path(
-  TRT_INCLUDE_DIR NvInfer.h
-  HINTS ${TRT_PACKAGE_DIR}
-  PATH_SUFFIXES include ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
-find_path(ONNX_PARSER_INCLUDE_DIR NvOnnxParser.h HINTS ${TRT_INCLUDE_DIR})
-if(NOT ONNX_PARSER_INCLUDE_DIR)
-  message(
-    FATAL_ERROR
-      "NvOnnxParser.h not found in TensorRT headers, please specify the -DONNX_PARSER_INCLUDE_DIR when invoking CMake"
-  )
-endif()
-
-find_library(
-  NVINFER_LIB nvinfer
-  HINTS ${TRT_PACKAGE_DIR}
-  PATH_SUFFIXES lib lib64 ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
-find_library(
-  NV_ONNX_PARSER_LIB nvonnxparser
-  HINTS ${TRT_PACKAGE_DIR}
-  PATH_SUFFIXES lib lib64 x86_64-linux-gnu)
+find_package(TensorRT REQUIRED COMPONENTS OnnxParser)
+message(STATUS "TensorRT_INCLUDE_DIR=${TensorRT_INCLUDE_DIR}")
+message(STATUS "TensorRT_LIBRARY=${TensorRT_LIBRARY}")
+message(STATUS "ONNX_PARSER_INCLUDE_DIR=${ONNX_PARSER_INCLUDE_DIR}")
+message(STATUS "NV_ONNX_PARSER_LIB=${NV_ONNX_PARSER_LIB}")
+message(STATUS "TensorRT_INCLUDE_DIRS=${TensorRT_INCLUDE_DIRS}")
+message(STATUS "TensorRT_LIBRARIES=${TensorRT_LIBRARIES}")
 
 # TRT and CUDA headers are treated as system includes so that the compiler
 # suppresses warnings originating from them (e.g. -Wunused-parameter in
@@ -153,6 +136,8 @@ find_library(
 include_directories(SYSTEM ${CUDA_INCLUDE_DIR} ${TRT_INCLUDE_DIR})
 
 set(COMMON_INCLUDE_DIRS
+    ${CUDA_INCLUDE_DIR}
+    ${TensorRT_INCLUDE_DIR}
     ${NVTX_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}/cpp
     ${CMAKE_SOURCE_DIR}/examples/multimodal
@@ -160,7 +145,8 @@ set(COMMON_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/3rdParty/stb)
 
 add_library(commonLibraryExt INTERFACE)
-target_link_libraries(commonLibraryExt INTERFACE ${NVINFER_LIB} ${CUDART_LIB})
+target_link_libraries(commonLibraryExt INTERFACE ${TensorRT_LIBRARY}
+                                                 ${CUDART_LIB})
 # Workaround for aarch64 cross compilation where libvninfer.so links to
 # libnvdla_compilers. The libnvinfer dependencies shall be resolved at execution
 # time on an embedded board.

--- a/cmake/FindTensorRT.cmake
+++ b/cmake/FindTensorRT.cmake
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# We prioritize TRT_PACKAGE_DIR to facilitate some x86 development systems where
+# multiple TensorRT versions might exist.
+if(NOT DEFINED TENSORRT_ROOT AND DEFINED TRT_PACKAGE_DIR)
+  set(TENSORRT_ROOT ${TRT_PACKAGE_DIR})
+endif()
+
+# Fallback to standard system paths (useful for systems that have TensorRT
+# bundled, such as JetPack, etc.)
+set(TRT_HINTS ${TENSORRT_ROOT} /usr /usr/local/cuda /opt/tensorrt)
+
+# Core TensorRT
+find_path(
+  TENSORRT_INCLUDE_DIR NvInfer.h
+  HINTS ${TRT_HINTS}
+  PATH_SUFFIXES
+    include include/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu # Ubuntu/JetPack layout
+    ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+find_library(
+  TENSORRT_LIBRARY nvinfer
+  HINTS ${TRT_HINTS}
+  PATH_SUFFIXES
+    lib lib64 lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu # Ubuntu/JetPack layout
+    ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+
+# Onnx parser
+find_path(ONNX_PARSER_INCLUDE_DIR NvOnnxParser.h HINTS ${TENSORRT_INCLUDE_DIR})
+find_library(
+  NV_ONNX_PARSER_LIB nvonnxparser
+  HINTS ${TRT_HINTS}
+  PATH_SUFFIXES lib lib64 ${CMAKE_SYSTEM_PROCESSOR}-linux-gnu)
+
+# Provide a targeted error message for partial installations where the core
+# library is found but the ONNX Parser is missing (consistent with legacy
+# behavior)
+if(TENSORRT_INCLUDE_DIR AND NOT ONNX_PARSER_INCLUDE_DIR)
+  message(
+    FATAL_ERROR
+      "NvOnnxParser.h not found in TensorRT headers, please specify the -DONNX_PARSER_INCLUDE_DIR when invoking CMake"
+  )
+endif()
+
+# Handling Onnx Parser component
+set(TensorRT_OnnxParser_FOUND OFF)
+if(ONNX_PARSER_INCLUDE_DIR AND NV_ONNX_PARSER_LIB)
+  set(TensorRT_OnnxParser_FOUND ON)
+endif()
+
+# Standard package handling for TensorRT
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  TensorRT
+  REQUIRED_VARS TENSORRT_LIBRARY TENSORRT_INCLUDE_DIR
+  HANDLE_COMPONENTS
+  REASON_FAILURE_MESSAGE
+  "TensorRT not found via auto-detection. Please specify -DTRT_PACKAGE_DIR=/path/to/TRT."
+)
+
+# Handling outputs
+if(TensorRT_FOUND)
+  # Only core TensorRT to allow for surgical linking
+  set(TensorRT_INCLUDE_DIR ${TENSORRT_INCLUDE_DIR})
+  set(TensorRT_LIBRARY ${TENSORRT_LIBRARY})
+
+  # Core + components
+  set(TensorRT_INCLUDE_DIRS ${TENSORRT_INCLUDE_DIR})
+  set(TensorRT_LIBRARIES ${TENSORRT_LIBRARY})
+
+  if(TensorRT_OnnxParser_FOUND)
+    set(ONNX_PARSER_INCLUDE_DIR ${ONNX_PARSER_INCLUDE_DIR})
+    set(NV_ONNX_PARSER_LIB ${NV_ONNX_PARSER_LIB})
+    list(APPEND TensorRT_INCLUDE_DIRS ${ONNX_PARSER_INCLUDE_DIR})
+    list(APPEND TensorRT_LIBRARIES ${NV_ONNX_PARSER_LIB})
+  endif()
+
+  list(REMOVE_DUPLICATES TensorRT_INCLUDE_DIRS)
+endif()

--- a/docs/source/user_guide/getting_started/installation.md
+++ b/docs/source/user_guide/getting_started/installation.md
@@ -224,7 +224,7 @@ cmake .. \
 
 | Option | Description | Default |
 |:-------|:------------|:--------|
-| `TRT_PACKAGE_DIR` | Path to TensorRT installation | Required |
+| `TRT_PACKAGE_DIR` | Path to TensorRT installation. Auto-detected; manual hint to disambiguate multiple versions. | N/A |
 | `CMAKE_TOOLCHAIN_FILE` | **Required for Edge devices**: Use `cmake/aarch64_linux_toolchain.cmake` for Edge device builds. **Not needed for GPU builds** | N/A |
 | `EMBEDDED_TARGET` | **Required for Edge devices**: `jetson-thor` (Jetson) or `auto-thor` (DRIVE / DriveOS). **Not needed for GPU builds** | N/A |
 | `CUDA_CTK_VERSION` | CUDA Toolkit version (such as 13.0). Important for matching target platform. | 13.0 |


### PR DESCRIPTION
## Summary

- Standardized TensorRT discovery by replacing manual header/library path checks with a `find_package` pattern. 
- Implemented component handling to allow surgical linking of the ONNX parser.
- Resolves: https://github.com/NVIDIA/TensorRT-Edge-LLM/issues/39

## What does this PR do?
We modernize the TensorRT discovery logic by implementing a `FindTensorRT.cmake` module. This replaces the manual and fragmented include dirs and library discovery code with a standardized `find_package` pattern.

## Usage
<!-- You can potentially add a usage example below. -->

```CMakeLists.txt
find_package(TensorRT REQUIRED COMPONENTS OnnxParser)
```

## Checklist
- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you add or update any necessary documentation?**: Yes