### PR TITLE
feat: Add multi-stage multi-arch Containerfile

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Build artifacts
+build/
+*.o
+*.so
+*.a
+
+# Python
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+.eggs/
+
+# Container
+Containerfile
+.containerignore
+
+# Dev / IDE (keep .git for submodule init in cpp-build stage)
+.github/
+.vscode/
+.idea/
+*.swp
+
+# Docs
+docs/
+
+# CI
+.pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+workspace/
 dist/
 *.egg-info
 *_engine/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## Next
+- Added multi-stage multi-arch Containerfile with container usage documentation
+
 ## 0.5.0
 - Implemented and used standalone embedding processing module to reduce multi-modal modeling complexity and reduce Eagle inference memory footprint
 - Added FP8 KV Cache support

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Multi-stage, multi-arch Containerfile for TensorRT Edge-LLM
+# See docs/source/developer_guide/getting-started/container.md for usage.
+
+ARG TRT_VERSION=25.03-py3
+
+# ---------------------------------------------------------------------------
+# Stage 1: Python export pipeline (model quantization & ONNX export)
+# ---------------------------------------------------------------------------
+FROM nvcr.io/nvidia/tensorrt:${TRT_VERSION} AS python-export
+
+WORKDIR /workspace/TensorRT-Edge-LLM
+
+# Install Python dependencies first for better layer caching, then copy source.
+COPY pyproject.toml requirements.txt ./
+COPY tensorrt_edgellm/ tensorrt_edgellm/
+RUN pip install --no-cache-dir .
+
+COPY . .
+
+# ---------------------------------------------------------------------------
+# Stage 2: C++ build (intermediate — not shipped)
+# ---------------------------------------------------------------------------
+FROM nvcr.io/nvidia/tensorrt:${TRT_VERSION} AS cpp-build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        build-essential \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/TensorRT-Edge-LLM
+
+COPY . .
+RUN git submodule update --init --recursive
+
+# Locate the CUDA driver stub (libcuda.so) portably across architectures.
+# In NGC containers without a GPU driver, the real libcuda.so is absent and
+# in that case we must find the stub that ships with the CUDA toolkit.
+RUN CUDA_DRIVER_STUB=$(find -L /usr/local/cuda -name 'libcuda.so' -path '*/stubs/*' 2>/dev/null | head -1) && \
+    if [ -z "$CUDA_DRIVER_STUB" ]; then echo "ERROR: libcuda.so stub not found" >&2; exit 1; fi && \
+    echo "Found CUDA driver stub: $CUDA_DRIVER_STUB" && \
+    mkdir build && cd build && \
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DTRT_PACKAGE_DIR=/usr \
+        -DCUDA_DIR=/usr/local/cuda \
+        -DCUDA_DRIVER_LIB="$CUDA_DRIVER_STUB" \
+        -DBUILD_UNIT_TESTS=OFF \
+    && cmake --build . --parallel "$(nproc)"
+
+# ---------------------------------------------------------------------------
+# Stage 3: Lean C++ runtime (no Python, no build tools)
+# ---------------------------------------------------------------------------
+FROM nvcr.io/nvidia/tensorrt:${TRT_VERSION} AS runtime
+
+WORKDIR /workspace
+
+# C++ binaries
+COPY --from=cpp-build /workspace/TensorRT-Edge-LLM/build/examples/llm/llm_build \
+                      /workspace/TensorRT-Edge-LLM/build/examples/llm/llm_inference \
+                      /usr/local/bin/
+COPY --from=cpp-build /workspace/TensorRT-Edge-LLM/build/examples/multimodal/visual_build \
+                      /usr/local/bin/
+
+# TensorRT plugin
+COPY --from=cpp-build /workspace/TensorRT-Edge-LLM/build/libNvInfer_edgellm_plugin.so* \
+                      /usr/local/lib/
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}" \
+    EDGELLM_PLUGIN_PATH="/usr/local/lib/libNvInfer_edgellm_plugin.so"
+
+ENTRYPOINT ["/bin/bash"]

--- a/docs/source/developer_guide/getting-started/container.md
+++ b/docs/source/developer_guide/getting-started/container.md
@@ -1,0 +1,235 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved. SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+
+# Container Images
+
+TensorRT Edge-LLM ships a multi-stage, multi-arch `Containerfile` that produces
+two image targets:
+
+| Target | Contents | Use case |
+|:-------|:---------|:---------|
+| `python-export` | Python export pipeline (quantization & ONNX export) | Model preparation |
+| *(default)* `runtime` | Lean C++ binaries only (no Python, no build tools) | Engine build + inference on x86 or aarch64 |
+
+The images are based on the
+[NGC TensorRT container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt)
+and support both **x86_64** (desktop/server GPU) and **aarch64** (Jetson / DRIVE).
+
+---
+
+## Building the Images
+
+> **Note:** `--target` selects which *build stage* to stop at.
+> `-t` (short for `--tag`) assigns a *name* to the resulting image.
+> Without `--target`, the build runs all stages and produces the final
+> `runtime` image.
+
+No GPU is required to **build** the images. The C++ stage links against a CUDA
+driver stub and the Python stage only installs packages. This makes it possible
+to build in CI pipelines or on headless servers, then deploy the images to
+GPU-equipped machines for inference.
+
+### C++ runtime (default target)
+
+```bash
+podman build -t tensorrt-edgellm .
+```
+
+### Python export pipeline
+
+```bash
+podman build --target python-export -t tensorrt-edgellm-export .
+```
+
+### Cross-build for aarch64 on an x86_64 host
+
+This requires `qemu-user-static` to be installed on the host.
+
+```bash
+podman build --platform linux/arm64 -t tensorrt-edgellm-arm64 .
+```
+
+### Build arguments
+
+| Argument | Description | Default |
+|:---------|:------------|:--------|
+| `TRT_VERSION` | NGC TensorRT image tag | `25.03-py3` |
+
+Example:
+
+```bash
+podman build --build-arg TRT_VERSION=25.06-py3 -t tensorrt-edgellm .
+```
+
+---
+
+## Example: Export a Model
+
+The `python-export` image comes with the full Python export pipeline
+pre-installed. A typical workflow quantizes a HuggingFace model and exports it
+to ONNX, producing files that can be compiled into TensorRT engines on the edge
+device.
+
+```bash
+# Launch the export container with GPU access and a shared output directory
+podman run --rm -it --device nvidia.com/gpu=all \
+  -v ./workspace:/workspace/output tensorrt-edgellm-export
+
+# --- inside the container ---
+
+# 1. Quantize (optional, skip for FP16/BF16)
+tensorrt-edgellm-quantize-llm \
+  --model_dir Qwen/Qwen3-0.6B \
+  --quantization fp8 \
+  --output_dir /workspace/output/quantized/
+
+# 2. Export to ONNX
+tensorrt-edgellm-export-llm \
+  --model_dir /workspace/output/quantized/ \
+  --output_dir /workspace/output/onnx/
+```
+
+The output directory will contain (example for Qwen3-0.6B with FP8):
+
+```
+workspace/
+├── quantized/
+│   ├── model.safetensors
+│   ├── modelopt_state.pth
+│   ├── config.json
+│   ├── generation_config.json
+│   ├── hf_quant_config.json
+│   ├── chat_template.jinja
+│   ├── tokenizer.json
+│   ├── tokenizer_config.json
+│   ├── special_tokens_map.json
+│   ├── added_tokens.json
+│   ├── merges.txt
+│   └── vocab.json
+└── onnx/
+    ├── model.onnx
+    ├── onnx_model.data
+    ├── config.json
+    ├── embedding.safetensors
+    ├── processed_chat_template.json
+    ├── chat_template.jinja
+    ├── tokenizer.json
+    ├── tokenizer_config.json
+    ├── special_tokens_map.json
+    ├── added_tokens.json
+    ├── merges.txt
+    └── vocab.json
+```
+
+> **Note:** The exact set of tokenizer files varies by model. For example,
+> SentencePiece-based models (e.g. Llama) produce a `tokenizer.model` file
+> instead of `merges.txt` and `vocab.json`.
+
+Transfer the `onnx/` directory to the edge device, then use the `runtime` image
+(or a native build) to compile it into TensorRT engines and run inference.
+
+### Available export tools
+
+| Command | Purpose |
+|:--------|:--------|
+| `tensorrt-edgellm-quantize-llm` | Quantize a model (FP8, INT4 AWQ, NVFP4, MXFP8, INT8 SQ) |
+| `tensorrt-edgellm-export-llm` | Export LLM to ONNX |
+| `tensorrt-edgellm-quantize-draft` | Quantize a speculative decoding draft model |
+| `tensorrt-edgellm-export-draft` | Export draft model to ONNX |
+| `tensorrt-edgellm-export-visual` | Export visual encoder (for VLMs) |
+| `tensorrt-edgellm-export-audio` | Export audio model |
+| `tensorrt-edgellm-insert-lora` | Add dynamic LoRA support to an ONNX model |
+| `tensorrt-edgellm-process-lora` | Process LoRA adapter weights |
+| `tensorrt-edgellm-merge-lora` | Merge LoRA weights into a base model |
+
+For detailed usage of each tool, run the command with `--help` or see the
+[Quick Start Guide](quick-start-guide.md) and [Examples](examples.md).
+
+---
+
+## Run with GPU
+
+### Prerequisites
+
+GPU access inside a container requires the
+[NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+with
+[CDI support](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html).
+
+After installing the toolkit, generate the CDI spec (required once, and after
+driver updates):
+
+```bash
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+# Verify that the GPU appears
+nvidia-ctk cdi list
+```
+
+### Podman (CDI)
+
+```bash
+podman run --rm -it --device nvidia.com/gpu=all \
+  -v ./workspace:/workspace/output tensorrt-edgellm
+```
+
+### Docker
+
+```bash
+docker run --rm -it --gpus all \
+  -v ./workspace:/workspace/output tensorrt-edgellm
+```
+
+---
+
+## Example: Build Engine and Run Inference
+
+After exporting a model to ONNX (see [above](#example-export-a-model)), launch
+the runtime container and build a TensorRT engine, then run inference.
+
+```bash
+# Launch the runtime container with GPU access
+podman run --rm -it --device nvidia.com/gpu=all \
+  -v ./workspace:/workspace/output tensorrt-edgellm
+
+# --- inside the container ---
+
+# 1. Build the TensorRT engine from the ONNX export
+llm_build --onnxDir /workspace/output/onnx --engineDir /workspace/output/engine
+
+# 2. Create a test input
+cat > /tmp/input.json << 'EOF'
+{
+    "max_generate_length": 128,
+    "requests": [
+        {
+            "messages": [
+                {"role": "user", "content": "What is TensorRT?"}
+            ]
+        }
+    ]
+}
+EOF
+
+# 3. Run inference
+llm_inference --engineDir /workspace/output/engine \
+  --inputFile /tmp/input.json \
+  --outputFile /tmp/output.json \
+  --dumpOutput
+```
+
+For the full input JSON format (multi-turn, multimodal, LoRA, etc.), see the
+[Input Format](input-format.md) documentation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ for large language models and vision-language models on edge devices.
    developer_guide/getting-started/overview.md
    developer_guide/getting-started/supported-models.md
    developer_guide/getting-started/installation.md
+   developer_guide/getting-started/container.md
    developer_guide/getting-started/quick-start-guide.md
    developer_guide/getting-started/examples.md
    developer_guide/getting-started/input-format.md


### PR DESCRIPTION
## What does this PR do?
Adds a multi-stage, multi-arch `Containerfile` that produces two image targets: a `python-export` image for model quantization and ONNX export and a leaner `runtime` image with only the C++ binaries for engine  building and inference. No GPU is required at build time, enabling CI and headless server builds. Also adds a documentation page covering build instructions, usage examples and available export tools.

Relates to #32. The file is named `Containerfile` rather than `Dockerfile` to reflect that it is an OCI-compliant container image, compatible with both Podman and Docker.

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->
new feature, documentation

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```bash
# Build the lean C++ runtime image (default)
podman build -t tensorrt-edgellm .

# Build the Python export pipeline image
podman build --target python-export -t tensorrt-edgellm-export .

# Cross-build for aarch64 on an x86_64 host
podman build --platform linux/arm64 -t tensorrt-edgellm-arm64 .

# Run with GPU access (Podman CDI)
podman run --rm -it --device nvidia.com/gpu=all \
  -v ./workspace:/workspace/output tensorrt-edgellm

# Run with GPU access (Docker)
docker run --rm -it --gpus all \
  -v ./workspace:/workspace/output tensorrt-edgellm
```

## Testing
<!-- Mention how have you tested your change if applicable. -->
All three image builds verified on x86_64 host with a RTX 3090 and a x84_64 host without a NVIDIA GPU :
- `podman build -t tensorrt-edgellm .` --> builds successfully (10.4 GB)
- `podman build --target python-export -t tensorrt-edgellm-export .` --> builds successfully (19 GB)
- `podman build --platform linux/arm64 -t tensorrt-edgellm-arm64 .` --> cross-builds successfully via qemu-user-static (10.4 GB, arm64)
- GPU passthrough validated with both Podman (CDI) and Docker (--gpus all)
- Exports and GPU accelerated inference works as expected

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: No. Container builds are validated manually; no CI container build pipeline exists yet in this project but could be added in a separate pull request.
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CHANGELOG.md)?**: Yes <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
I verified arm64 container builds via cross compiling but I do not have any arm64 hardware capable of connecting to a NVIDIA GPU available. I expect everything to work just fine, but I suggest that someone with access to arm64 hardware test this before merging this pull request.