### PR TITLE
fix: propagate CuTe DSL runtime link requirements for static libraries

### DIFF
--- a/cmake/CuteDsl.cmake
+++ b/cmake/CuteDsl.cmake
@@ -769,25 +769,34 @@ function(cute_dsl_setup)
 
   # Link the static archive + shim + driver lib into LINK_TARGETS.
   #
-  # For STATIC libraries, use PUBLIC so executables that link edgellmCore /
-  # edgellmKernels also inherit the CuTe DSL archive. Otherwise unresolved AOT
-  # wrapper symbols only show up at the final executable link step.
+  # For STATIC libraries, propagate the archive, cudart shim, driver library,
+  # and wrap option to dependents. The final executable performs the actual link
+  # step, so it must inherit all CuTe DSL runtime compatibility pieces.
   foreach(_tgt ${ARG_LINK_TARGETS})
     get_target_property(_tgt_type ${_tgt} TYPE)
     if(_tgt_type STREQUAL "STATIC_LIBRARY")
-      target_link_libraries(${_tgt} PUBLIC "${_static_lib}")
+      target_link_libraries(${_tgt} PUBLIC "${_static_lib}"
+                                           trt_edgellm_cutedsl_cudart_shim)
     else()
       target_link_libraries(${_tgt} PRIVATE "${_static_lib}"
                                             trt_edgellm_cutedsl_cudart_shim)
     endif()
     if(CUDA_DRIVER_LIB AND NOT CUDA_DRIVER_LIB MATCHES "-NOTFOUND$")
-      target_link_libraries(${_tgt} PRIVATE "${CUDA_DRIVER_LIB}")
+      if(_tgt_type STREQUAL "STATIC_LIBRARY")
+        target_link_libraries(${_tgt} PUBLIC "${CUDA_DRIVER_LIB}")
+      else()
+        target_link_libraries(${_tgt} PRIVATE "${CUDA_DRIVER_LIB}")
+      endif()
     endif()
     # CUDA < 12.8: wrap _cudaLaunchKernelEx (cudaKernel_t → CUfunction, e.g.
     # JetPack 6).
     if(NOT _cute_dsl_cuda_ver STREQUAL "" AND _cute_dsl_cuda_ver VERSION_LESS
                                               12.8)
-      target_link_options(${_tgt} PRIVATE "-Wl,--wrap=_cudaLaunchKernelEx")
+      if(_tgt_type STREQUAL "STATIC_LIBRARY")
+        target_link_options(${_tgt} INTERFACE "-Wl,--wrap=_cudaLaunchKernelEx")
+      else()
+        target_link_options(${_tgt} PRIVATE "-Wl,--wrap=_cudaLaunchKernelEx")
+      endif()
     endif()
   endforeach()
 


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:**  
This PR fixes CuTe DSL link propagation for static library targets.

Before this change, `cute_dsl_setup()` did not propagate all CuTe DSL runtime compatibility pieces when the target type was `STATIC_LIBRARY`. As a result, downstream executables could fail during the final link step because they did not inherit all required link dependencies and options.

This change updates the static-library path to propagate:
- the CuTe DSL static archive
- the CuTe DSL cudart shim
- the CUDA driver library
- the `_cudaLaunchKernelEx` wrap linker option for CUDA `< 12.8`

The existing private-link behavior for non-static targets is preserved.

## Usage

This is a build-system fix only. No user-facing API or runtime usage change is introduced.

## 🚀 Pull Request Checklist

Thank you for contributing to TensorRT Edge-LLM! Before we review your pull request, please make sure the following items are complete.
Please also refer to [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md) for general guidelines.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing.

### 📄 Documentation

- [ ] Updated any necessary documentation

### ⚙️ Compatibility

- [x] The change is backward compatible

## Additional Information

### Reproduction environment

The issue was reproduced during cross-build configuration for Jetson Orin with:

- `-DCMAKE_BUILD_TYPE=Release`
- `-DTRT_PACKAGE_DIR=/usr`
- `-DCMAKE_TOOLCHAIN_FILE=cmake/aarch64_linux_toolchain.cmake`
- `-DEMBEDDED_TARGET=jetson-orin`
- `-DCUDA_CTK_VERSION=12.6`
- `-DENABLE_CUTE_DSL=ALL`

### Failure before this fix

Before this change, the build failed at the final executable link step for `llm_inference` with unresolved CuTe DSL CUDA runtime symbols:

```text
/usr/bin/ld: ../../../cpp/kernels/cuteDSLArtifact/aarch64/sm_87/libcutedsl_aarch64.a(CudaDialectRuntime.c.o): in function `_cudaLibraryLoadData':
(.text+0x0): undefined reference to `cudaLibraryLoadData'
/usr/bin/ld: ../../../cpp/kernels/cuteDSLArtifact/aarch64/sm_87/libcutedsl_aarch64.a(CudaDialectRuntime.c.o): in function `_cudaLibraryUnload':
(.text+0x8): undefined reference to `cudaLibraryUnload'
/usr/bin/ld: ../../../cpp/kernels/cuteDSLArtifact/aarch64/sm_87/libcutedsl_aarch64.a(CudaDialectRuntime.c.o): in function `_cudaLibraryGetKernel':
(.text+0x10): undefined reference to `cudaLibraryGetKernel'
/usr/bin/ld: ../../../cpp/kernels/cuteDSLArtifact/aarch64/sm_87/libcutedsl_aarch64.a(CudaDialectRuntime.c.o): in function `_cudaKernelSetAttributeForDevice':
(.text+0x20): undefined reference to `cudaKernelSetAttributeForDevice'
collect2: error: ld returned 1 exit status
make[2]: *** [examples/llm/CMakeFiles/llm_inference.dir/build.make:131: examples/llm/llm_inference] Error 1
make[1]: *** [CMakeFiles/Makefile2:389: examples/llm/CMakeFiles/llm_inference.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

### Validation after this fix

Validation performed locally:

- `pre-commit run --files cmake/CuteDsl.cmake`
- Configure succeeded with:
  - `cmake .. -DCMAKE_BUILD_TYPE=Release -DTRT_PACKAGE_DIR=/usr -DCMAKE_TOOLCHAIN_FILE=cmake/aarch64_linux_toolchain.cmake -DEMBEDDED_TARGET=jetson-orin -DCUDA_CTK_VERSION=12.6 -DENABLE_CUTE_DSL=ALL`
- Build succeeded
- Runtime binary startup validation succeeded

Relevant successful outputs after this fix included:

```text
[100%] Linking CXX shared library ../libNvInfer_edgellm_plugin.so
[100%] Built target NvInfer_edgellm_plugin
```

```text
./examples/llm/llm_inference --help
Usage: ./examples/llm/llm_inference [--help] [--engineDir=<path to engine directory>] [--multimodalEngineDir=<path to multimodal engine directory>] [--inputFile=<path to input file>] [--outputFile=<path to output file>] [--dumpProfile] [--profileOutputFile=<path to profile output file>] [--warmup=<number>] [--debug] [--dumpOutput] [--batchSize=<number>] [--maxGenerateLength=<number>] [--specDecode] [--specDraftTopK=<number>] [--specDraftStep=<number>] [--specVerifySize=<number>]
```

### Risk

Low. The change only adjusts link visibility and propagation for CuTe DSL-related dependencies and link options for static-library targets, while preserving the existing behavior for non-static targets.