### PR TITLE
fix: Respect native Orin CUDA architecture and CuTe link requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,16 @@
 
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
+# Record whether the user explicitly requested CUDA architectures before
+# project() runs. enable_language(CUDA) initializes CMAKE_CUDA_ARCHITECTURES to
+# a compiler default, so testing it afterwards cannot distinguish a
+# user-provided value from that default.
+set(_EDGELLM_USER_CUDA_ARCHS FALSE)
+if(DEFINED CMAKE_CUDA_ARCHITECTURES
+   AND NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "")
+  set(_EDGELLM_USER_CUDA_ARCHS TRUE)
+endif()
+
 project(
   tensorrt_edgellm_sdk
   VERSION 0.9.1
@@ -61,7 +71,7 @@ endif()
 set_ifndef(CUDA_CTK_VERSION 12.8)
 set_ifndef(CUDA_DIR /usr/local/cuda-${CUDA_CTK_VERSION})
 
-if(NOT DEFINED AARCH64_BUILD)
+if(NOT _EDGELLM_USER_CUDA_ARCHS AND NOT DEFINED AARCH64_BUILD)
   set(CMAKE_CUDA_ARCHITECTURES 80;86;89)
   if(CUDA_CTK_VERSION VERSION_GREATER_EQUAL 12.8)
     list(APPEND CMAKE_CUDA_ARCHITECTURES 100a 120)

--- a/cmake/CuteDsl.cmake
+++ b/cmake/CuteDsl.cmake
@@ -1043,7 +1043,8 @@ function(cute_dsl_setup)
   foreach(_tgt ${ARG_LINK_TARGETS})
     get_target_property(_tgt_type ${_tgt} TYPE)
     if(_tgt_type STREQUAL "STATIC_LIBRARY")
-      target_link_libraries(${_tgt} PUBLIC ${_link_libs})
+      target_link_libraries(${_tgt} PUBLIC ${_link_libs}
+                                           trt_edgellm_cutedsl_cudart_shim)
     else()
       target_link_libraries(${_tgt} PRIVATE ${_link_libs}
                                             trt_edgellm_cutedsl_cudart_shim)
@@ -1056,7 +1057,12 @@ function(cute_dsl_setup)
     if(NOT _cute_dsl_cuda_ver STREQUAL ""
        AND _cute_dsl_cuda_ver VERSION_GREATER_EQUAL 12.0
        AND _cute_dsl_cuda_ver VERSION_LESS 12.8)
-      target_link_options(${_tgt} PRIVATE "-Wl,--wrap=_cudaLaunchKernelEx")
+      if(_tgt_type STREQUAL "STATIC_LIBRARY")
+        target_link_options(${_tgt} INTERFACE
+                            "-Wl,--wrap=_cudaLaunchKernelEx")
+      else()
+        target_link_options(${_tgt} PRIVATE "-Wl,--wrap=_cudaLaunchKernelEx")
+      endif()
     endif()
   endforeach()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the two CMake propagation issues reported in #117 that block a native
Jetson Orin build with JetPack 6 / CUDA 12.6:

1. Capture an explicitly supplied `CMAKE_CUDA_ARCHITECTURES` before
   `project()` enables CUDA, so the project default no longer replaces
   `-DCMAKE_CUDA_ARCHITECTURES=87`.
2. For CuTe DSL link targets that are static libraries, propagate the cudart
   shim with `PUBLIC` scope and the CUDA 12.0–12.6
   `-Wl,--wrap=_cudaLaunchKernelEx` option with `INTERFACE` scope. The existing
   behavior for non-static targets is unchanged.

This branch has been rebuilt on the current v0.9.1 `main`
(`7f061f21f0a581ba234a1e233c9315b89d8e47d6`). The v0.8-era patch was not
blindly rebased because `cmake/CuteDsl.cmake` changed substantially in v0.9.1.

## Scope

- Two CMake files only.
- No runtime, model, kernel, or API changes.
- `CUDA_DRIVER_LIB` remains `PRIVATE`; this PR does not expand its transitive
  link scope.
- Default x86 architecture selection and the AArch64 toolchain path retain
  their existing behavior.

## Validation

- Focused CMake checks cover explicit SM87, default native, and AArch64
  toolchain architecture selection.
- A focused harness including the updated `cmake/CuteDsl.cmake` verifies that a
  static consumer exposes the CuTe archive and shim through
  `INTERFACE_LINK_LIBRARIES`, and exposes `--wrap=_cudaLaunchKernelEx` through
  `INTERFACE_LINK_OPTIONS`.
- The same harness verifies that `CUDA_DRIVER_LIB` remains private.
- `git diff --check` passes.
- A merge-tree check against current `main` is clean.

A native Orin build and the repository-wide pre-commit suite were not rerun on
the machine used for this v0.9.1 rebase because it has no CUDA/Jetson toolchain
or repository `pre-commit` environment. CI or Jetson validation is therefore
still requested.

Closes #117.
