### PR TITLE
Use <cmath> instead of <math.h> in context attention FMHA headers

### DIFF
--- a/cpp/kernels/contextAttentionKernels/contextFMHARunner.cpp
+++ b/cpp/kernels/contextAttentionKernels/contextFMHARunner.cpp
@@ -24,7 +24,7 @@
 #include <cstring>
 #include <cuda.h>
 #include <cuda_fp16.h>
-#include <math.h>
+#include <cmath>
 #include <memory>
 #include <mutex>
 #include <unordered_map>

--- a/cpp/kernels/contextAttentionKernels/fmhaParams_v2.h
+++ b/cpp/kernels/contextAttentionKernels/fmhaParams_v2.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <limits.h>
-#include <math.h>
+#include <cmath>
 #include <stdint.h>
 
 //! \brief Parameters for ALiBi (Attention with Linear Biases) positional encoding


### PR DESCRIPTION
## Summary
- Replace C-style `<math.h>` includes in the context attention FMHA code with the C++ `<cmath>` header (`contextFMHARunner.cpp`, `fmhaParams_v2.h`).
- Motivated by a compile failure on Jetson/Thor where CUDA include paths cause `<math.h>` to resolve through CUDA wrapper headers when transitively included from `fmhaParams_v2.h`. `<cmath>` avoids that C-header leakage.
- No runtime behavior change intended.

## Test plan
- [ ] Local build of `cpp/` succeeds on Jetson/Thor (CUDA 13.2) without the prior `<math.h>` resolution error.
- [ ] Existing FMHA / context attention unit tests still pass.
- [ ] Spot-check that no other translation unit relied on macros only exposed by `<math.h>` (e.g. `M_PI`) — none observed in the two touched files.