### PR TITLE
Strip /usr/include from apt pybind11's interface include dirs

### DIFF
--- a/experimental/pybind/CMakeLists.txt
+++ b/experimental/pybind/CMakeLists.txt
@@ -111,6 +111,31 @@ find_package(
   REQUIRED)
 find_package(pybind11 CONFIG REQUIRED)
 
+# ── Work around Debian/Ubuntu pybind11-dev exporting /usr/include ─────────
+# The apt-installed `pybind11-dev` package ships a CMake config whose
+# `pybind11::pybind11_headers` target sets
+#     INTERFACE_INCLUDE_DIRECTORIES = ${_IMPORT_PREFIX}/include
+# and `_IMPORT_PREFIX` resolves to `/usr`, so `/usr/include` gets propagated
+# to every consumer via `-isystem`. When nvcc then invokes host g++ on a CUDA
+# source, `-isystem /usr/include` reorders g++'s system header chain and
+# places `/usr/include` before `/usr/include/c++/<ver>`. libstdc++'s <cmath>
+# uses `#include_next <math.h>`, which now finds nothing after itself in the
+# search order, and compilation fails with:
+#   /usr/include/c++/13/cmath: fatal error: math.h: No such file or directory
+# Filter `/usr/include` out of the interface so the real pybind11 headers
+# (in a subdirectory under _IMPORT_PREFIX) are still exposed but the bogus
+# root include is not. No-op for pip-installed pybind11 (its _IMPORT_PREFIX
+# points at the venv's site-packages, not /usr).
+if(TARGET pybind11::pybind11_headers)
+  get_target_property(_pybind11_iface_inc pybind11::pybind11_headers
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  if(_pybind11_iface_inc)
+    list(REMOVE_ITEM _pybind11_iface_inc "/usr/include")
+    set_property(TARGET pybind11::pybind11_headers PROPERTY
+                 INTERFACE_INCLUDE_DIRECTORIES "${_pybind11_iface_inc}")
+  endif()
+endif()
+
 # ── Header include paths (from source tree) ───────────────────────────────
 set(EDGELLM_INCLUDE_DIRS
     ${EDGELLM_ROOT}/cpp ${EDGELLM_ROOT}/examples/multimodal


### PR DESCRIPTION
## Summary
- On Debian/Ubuntu hosts, the apt `pybind11-dev` CMake config sets `pybind11::pybind11_headers` `INTERFACE_INCLUDE_DIRECTORIES` to `${_IMPORT_PREFIX}/include`, where `_IMPORT_PREFIX=/usr`. That leaks `/usr/include` into every target using `pybind11_add_module` — in this repo, `_edgellm_runtime`.
- nvcc translates it to `-isystem /usr/include` on the host g++ command line, which reorders g++'s system include chain and puts `/usr/include` *before* `/usr/include/c++/<ver>`. libstdc++'s `<cmath>` then fails to satisfy `#include_next <math.h>` and the build dies during `device_link_stub.cu.o`:
  ```
  /usr/include/c++/13/cmath: fatal error: math.h: No such file or directory
     #include_next <math.h>
  ```
- Fix: after `find_package(pybind11 CONFIG REQUIRED)`, remove the literal `/usr/include` entry from `pybind11::pybind11_headers`'s interface include dirs. The real pybind11 headers still resolve; only the bogus root include is dropped.
- No-op for pip-installed pybind11 (its `_IMPORT_PREFIX` is under the venv's site-packages, not `/usr`).

## Reproduction
- Host: Ubuntu 24.04 aarch64 (Jetson Thor), gcc 13.3.0, CUDA 13.2.
- Apt package: `pybind11-dev 2.11.1-2` at `/usr/lib/cmake/pybind11/`.
- Configure:
  ```
  cmake .. \
      -DTRT_PACKAGE_DIR=/usr \
      -DCUDA_CTK_VERSION=13.2 \
      -DCMAKE_TOOLCHAIN_FILE=cmake/aarch64_linux_toolchain.cmake \
      -DEMBEDDED_TARGET=jetson-thor \
      -DENABLE_CUTE_DSL=ALL \
      -DENABLE_NVTX_PROFILING=ON \
      -DBUILD_PYTHON_BINDINGS=ON
  ```
- Without this patch: build fails compiling `experimental/pybind/device_link_stub.cu` with the `<cmath>` / `math.h` error above.
- With this patch: `experimental/pybind/CMakeFiles/_edgellm_runtime.dir/includes_CUDA.rsp` no longer contains a bare `-isystem /usr/include`, and `_edgellm_runtime.cpython-312-aarch64-linux-gnu.so` links successfully.
- Also verified that pip-installed pybind11 3.0.4 (via `-Dpybind11_DIR="$(python -m pybind11 --cmakedir)"`) continues to work with this patch — the workaround is guarded on the presence of `/usr/include` in the interface list.

## Test plan
- [ ] Configure + build with apt `pybind11-dev` on Ubuntu 24.04 aarch64 (Jetson Thor) — `_edgellm_runtime` target builds.
- [ ] Configure + build with pip-installed `pybind11` via `-Dpybind11_DIR=$(python -m pybind11 --cmakedir)` — still builds, no regression.
- [ ] `python -c "import _edgellm_runtime"` succeeds against the resulting `.so`.
- [ ] Spot-check that no other target consuming `pybind11::*` targets is affected on x86_64.

## Related
- Independent of the `<cmath>` header cleanup in #120 (which changes source files, not build system); this PR fixes a distinct build-system issue and does not depend on it.