### PR TITLE
fix: Guard FP4 data type before TensorRT 10.8

### DIFF
--- a/cpp/plugins/fusedNvfp4GemmAllReducePlugin/fusedNvfp4GemmAllReducePlugin.cpp
+++ b/cpp/plugins/fusedNvfp4GemmAllReducePlugin/fusedNvfp4GemmAllReducePlugin.cpp
@@ -215,11 +215,19 @@ bool FusedNvfp4GemmAllReducePlugin::supportsFormatCombination(
     }
     if (pos == kFP4_ACT_IDX)
     {
+#if NV_TENSORRT_MAJOR >= 11 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 8)
         return desc.type == DataType::kFP4 || desc.type == DataType::kINT8 || desc.type == DataType::kFP8;
+#else
+        return desc.type == DataType::kINT8 || desc.type == DataType::kFP8;
+#endif
     }
     if (pos == kFP4_WEIGHT_IDX)
     {
+#if NV_TENSORRT_MAJOR >= 11 || (NV_TENSORRT_MAJOR == 10 && NV_TENSORRT_MINOR >= 8)
         return desc.type == DataType::kFP4 || desc.type == DataType::kINT8 || desc.type == DataType::kFP8;
+#else
+        return desc.type == DataType::kINT8 || desc.type == DataType::kFP8;
+#endif
     }
     if (pos == kFP4_ACT_SCALE_IDX)
     {


### PR DESCRIPTION
## What does this PR do?

Guards the two remaining `nvinfer1::DataType::kFP4` references in
`FusedNvfp4GemmAllReducePlugin::supportsFormatCombination()` so the source can
be compiled with TensorRT releases before 10.8, where that enum value does not
exist.

For TensorRT 10.8 and newer, the original FP4/INT8/FP8 acceptance expression is
unchanged. For older TensorRT releases, the existing INT8 and FP8 alternatives
remain available without referencing `kFP4`.

## Scope

- One source file.
- No plugin ABI, serialization, kernel, or model changes.
- No behavior change for TensorRT 10.8+.

## Validation

- Focused compile/preprocessor matrix passed for simulated TensorRT 10.3,
  10.7, 10.8, and 11.0 version macros.
- TensorRT 10.7 preprocessing contains no `DataType::kFP4` references.
- TensorRT 10.8 preprocessing retains both original FP4 checks.
- An unguarded negative control fails against the pre-10.8 enum as expected.
- `git diff --check` passes.

The machine used for this focused validation does not have a Jetson
TensorRT/CUDA toolchain, so a complete JetPack 6.2 plugin build is still
requested from CI or device validation.

Closes #141.
