### PR TITLE
fix: Normalize ASR MRoPE metadata for runtime

### DIFF
--- a/tensorrt_edgellm/checkpoint/checkpoint_utils.py
+++ b/tensorrt_edgellm/checkpoint/checkpoint_utils.py
@@ -61,7 +61,7 @@ def normalize_rope_scaling_for_runtime(rope_scaling: Any) -> Any:
     normalized = dict(rope_scaling)
     if "mrope_section" in normalized:
         rope_type = normalized.get("type") or normalized.get("rope_type")
-        if rope_type in (None, "default", "mrope"):
+        if rope_type in (None, "default", "linear", "mrope"):
             normalized["type"] = "default"
             normalized["rope_type"] = "default"
     # rope_parameters (transformers v5) carries "rope_type" without "type";

--- a/tests/python-unittests/test_checkpoint_utils.py
+++ b/tests/python-unittests/test_checkpoint_utils.py
@@ -37,8 +37,8 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 try:
-    from tensorrt_edgellm.checkpoint.checkpoint_utils import \
-        load_checkpoint_config_dicts
+    from tensorrt_edgellm.checkpoint.checkpoint_utils import (
+        load_checkpoint_config_dicts, normalize_rope_scaling_for_runtime)
 except ImportError as exc:  # pragma: no cover
     pytest.skip(f"tensorrt_edgellm not importable: {exc}",
                 allow_module_level=True)
@@ -93,6 +93,39 @@ def _assert_kmrope(rope_scaling):
     assert rope_type in ("default", "mrope"), (
         "rope type must be 'default' (+ mrope_section) or 'mrope' "
         f"for kMRope; got {rope_type!r}")
+
+
+def test_linear_rope_with_mrope_section_is_normalized_for_runtime():
+    """Qwen3-ASR uses linear scaling metadata for an MRoPE configuration."""
+    source = {
+        "factor": 1.0,
+        "mrope_section": [24, 20, 20],
+        "rope_type": "linear",
+    }
+
+    normalized = normalize_rope_scaling_for_runtime(source)
+
+    assert normalized == {
+        "factor": 1.0,
+        "mrope_section": [24, 20, 20],
+        "rope_type": "default",
+        "type": "default",
+    }
+    assert source["rope_type"] == "linear"
+
+
+def test_linear_rope_without_mrope_section_keeps_linear_semantics():
+    """Ordinary linear RoPE must not be classified as MRoPE."""
+    normalized = normalize_rope_scaling_for_runtime({
+        "factor": 2.0,
+        "rope_type": "linear",
+    })
+
+    assert normalized == {
+        "factor": 2.0,
+        "rope_type": "linear",
+        "type": "linear",
+    }
 
 
 def test_qwen3_vl_transformers_v5_recovers_rope_from_text_config_rope_parameters(


### PR DESCRIPTION
## What does this PR do?

Extends the existing runtime RoPE normalization to recognize checkpoint
metadata that combines `rope_type: linear` with `mrope_section`.

That combination describes an MRoPE layout used by Qwen3-ASR checkpoints, but
the runtime accepts the existing normalized `default + mrope_section` form.
Without this normalization, export preserves `linear` and the runtime does not
select its MRoPE path.

The input dictionary is copied rather than mutated. Ordinary linear RoPE
metadata without `mrope_section` remains unchanged.

## Scope

- One production-line change in the existing normalization helper.
- Two focused regression tests.
- No model-name, local path, runtime, engine, or product-specific branches.

## Validation

- Focused regression tests: `2 passed`.
- Positive case verifies `linear + mrope_section` becomes
  `default + mrope_section` without mutating the source.
- Negative case verifies ordinary linear RoPE keeps linear semantics.
- Python syntax, focused formatting checks, `git diff --check`, and merge-tree
  validation pass.

This is a configuration-normalization regression test. A complete
export → build → inference validation requires the model and GPU environment
and is still requested from CI/device testing.

Closes #142.
