### PR TITLE
Fixes #158 : avoid duplicate add Qwen3.5 shared expert output

### DIFF
--- a/tensorrt_edgellm/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/tensorrt_edgellm/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -76,11 +76,6 @@ class Qwen3_5SparseMoeBlock(Qwen3SparseMoeBlock):
             1,
             module_name=f"{prefix}.shared_expert_gate")
 
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        routed = super().forward(hidden_states)
-        shared = self.shared_expert(hidden_states)
-        shared_gate = torch.sigmoid(self.shared_expert_gate(hidden_states))
-        return routed + shared * shared_gate
 
 
 class Qwen3_5MoeDecoderLayer(Qwen3_5DecoderLayer):


### PR DESCRIPTION
## What does this PR do?

**Type of change:**  Bug fix

**Overview:** Fixes duplicate shared-expert accumulation in the Qwen3.5 MoE forward path. `Qwen3SparseMoeBlock.forward()` already combines the routed-expert output with the gated shared-expert output. `Qwen3_5SparseMoeBlock.forward()` previously called the base implementation and then added the same shared-expert output again, casue erros;

## Usage
No user-facing API or workflow changes are required. Export Qwen3.5 MoE models using the existing documented workflow.


## 🚀 Pull Request Checklist

Thank you for contributing to TensorRT Edge-LLM! Before we review your pull request, please make sure the following items are complete.
Please also refer to [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md) for general guidelines.

### ✅ Pre-commit Checks

- ✅ I have installed `pre-commit` by running `pip install pre-commit`.
- ✅ I have installed the hooks with `pre-commit install`.
- ✅ I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing.


### 📄 Documentation
- Documentation updates are not required because this change only corrects internal model execution behavior.

### ⚙️ Compatibility
- ✅ The change is backward compatible

