### PR TITLE
fix #161: XQA cubin generation ignores resolved output dir under spawn/forkserver

### DIFF
--- a/kernelSrcs/xqa/gen_cubins.py
+++ b/kernelSrcs/xqa/gen_cubins.py
@@ -454,6 +454,18 @@ def convert_cubin_cpp_np(cubin_file_name: str):
     return cpp_array, cubin_size
 
 
+def init_cubin_gen_worker(worker_cubin_dir: str, worker_nvcc_bin: str,
+                          worker_clean_cubin: bool):
+    # Workers under a start method that re-imports this module (spawn/forkserver)
+    # never execute the `if __name__ == "__main__":` block, so the module-scope
+    # defaults for these globals would otherwise be used instead of the values
+    # resolved from CLI args. Set them explicitly in each worker process.
+    global cubin_dir, nvcc_bin, clean_cubin
+    cubin_dir = worker_cubin_dir
+    nvcc_bin = worker_nvcc_bin
+    clean_cubin = worker_clean_cubin
+
+
 def run_cubin_gen(arch_micro_file_list: CompileArchMacrosAndFile):
     nvcc_command, xxd_command, cubin_file_name = build_commands(
         build_func_name_prefix, arch_micro_file_list.arch,
@@ -833,7 +845,10 @@ if __name__ == "__main__":
 
     cpu_count = os.cpu_count()
     thread_count = cpu_count // 2 if cpu_count >= 2 else cpu_count
-    with multiprocessing.Pool(processes=thread_count) as pool:
+    with multiprocessing.Pool(
+            processes=thread_count,
+            initializer=init_cubin_gen_worker,
+            initargs=(cubin_dir, nvcc_bin, clean_cubin)) as pool:
         name_size_list = pool.map(run_cubin_gen, arch_macro_lists)
     header_file_contents = generate_header_file_contents(
         arch_macro_lists, name_size_list)


### PR DESCRIPTION
## Summary

Fixes the latent bug identified in #161 (separate from the permissions/OS-specific
failure discussed there). `gen_cubins.py`'s worker pool reads the module-scope
`cubin_dir` / `nvcc_bin` / `clean_cubin` globals, which are only rebound to their
CLI-resolved values inside `if __name__ == "__main__":`. Worker processes never
execute that block when the multiprocessing start method re-imports the module
(`spawn`/`forkserver`) instead of forking, so they silently fall back to the
relative module-level default for `cubin_dir` instead of the resolved
`--output_dir`.

Under `fork` (Linux's current default) this is masked because child processes
inherit the parent's post-`__main__` state — which is why it hasn't caused
visible failures so far. It will start affecting `fork`-based setups too once
Python 3.14 switches Linux's default start method to `forkserver`.

## Changes

- Added `init_cubin_gen_worker()` and pass it to `multiprocessing.Pool` via
  `initializer=`/`initargs=`, so each worker gets the resolved
  `cubin_dir`/`nvcc_bin`/`clean_cubin` explicitly rather than relying on
  inherited module state.

`kernelSrcs/` is excluded from this repo's pre-commit hooks, so no formatting
changes were needed beyond the diff itself.

## Test plan

- [x] `python3 -m py_compile kernelSrcs/xqa/gen_cubins.py`
- [ ] Maintainer/CI: run XQA cubin generation under a non-`fork` multiprocessing
      start method (e.g. `multiprocessing.set_start_method("spawn")`) to confirm
      the fix, since I don't have a repro environment for that start method on
      this hardware (Python 3.12.3 on Jetson Orin NX defaults to `fork`).