### PR TITLE
fix(qwen3_5): skip GDN input-projection fusion on mixed projection dt…

### DIFF
--- a/tensorrt_edgellm/models/qwen3_5/modeling_qwen3_5_text.py
+++ b/tensorrt_edgellm/models/qwen3_5/modeling_qwen3_5_text.py
@@ -807,6 +807,17 @@ def fuse_gdn_input_projections(model: nn.Module) -> int:
         # --- Fuse: concatenate weights along output dim (dim 0) ----------
         fused_buffers: dict = {}
         proj_modules = [getattr(mixer, n) for n in _GDN_PROJ_NAMES]
+        # Anti-compressed checkpoints can quantize only some GDN projections
+        # (e.g. in_proj_qkv/z -> NVFP4 FP8, in_proj_b/a -> FP16); a single cat
+        # cannot mix those dtypes, so keep the unfused path in that case.
+        wptrs = [getattr(p, "weight", None) for p in proj_modules]
+        if any(wp is None for wp in wptrs) or len({wp.dtype
+                                                   for wp in wptrs}) != 1:
+            logger.warning(
+                "GDN fusion skipped for %s: projections have mixed weight "
+                "dtypes (%s).", name,
+                ", ".join(sorted(str(wp.dtype) for wp in wptrs)))
+            continue
         for attr in list(proj_modules[0]._buffers) + list(
                 proj_modules[0]._parameters):
             parts = [getattr(p, attr) for p in proj_modules]


### PR DESCRIPTION
…ypes

Anti-compressed NVFP4 checkpoints can quantize only some GDN input projections (e.g. in_proj_qkv/in_proj_z -> NVFP4 FP8 weights) while leaving others (in_proj_b/in_proj_a) FP16. fuse_gdn_input_projections checked only the first projection's quant type and then concat weights of all four projections, so these checkpoints crashed with 'Promotion for Float8 Types is not supported, attempted to promote Float8_e4m3fn and Half'.

Verify all four projections share the same weight dtype before fusing; when they differ, log a warning and keep the unfused path (which is already supported in forward()). Pure FP16 / pure NVFP4 models still fuse.

Verified: tensorrt-edgellm-export Qwen3.8-27B-NVFP4 --skip-audio completes, with 'GDN fusion skipped' warnings logged per layer.

## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## 🚀 Pull Request Checklist

Thank you for contributing to TensorRT Edge-LLM! Before we review your pull request, please make sure the following items are complete.
Please also refer to [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Edge-LLM/blob/main/CONTRIBUTING.md) for general guidelines.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit`.
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing.


### 📄 Documentation
- [ ] Updated any necessary documentation

### ⚙️ Compatibility
- [ ] The change is backward compatible

## Additional Information
<!-- E.g. related issue. -->
