### PR TITLE
fix #184: Support Hugging Face cache symlinks for checkpoint shards

### DIFF
--- a/tensorrt_edgellm/checkpoint/loader.py
+++ b/tensorrt_edgellm/checkpoint/loader.py
@@ -281,14 +281,37 @@ def _detect_key_prefix(keys: list) -> Tuple[str, str]:
 def _resolve_shard(model_dir: str, shard: str) -> str:
     """Return the absolute shard path, asserting it stays inside model_dir."""
     base = pathlib.Path(model_dir).resolve()
-    resolved = (base / shard).resolve()
+    shard_path = pathlib.Path(shard)
+    if shard_path.is_absolute():
+        raise ValueError(
+            f"Shard path {shard!r} in checkpoint index escapes model_dir "
+            f"{model_dir!r}. This may indicate a malformed checkpoint.")
+
+    candidate = pathlib.Path(os.path.abspath(base / shard_path))
     try:
-        resolved.relative_to(base)
+        candidate.relative_to(base)
     except ValueError:
         raise ValueError(
             f"Shard path {shard!r} in checkpoint index escapes model_dir "
             f"{model_dir!r}. This may indicate a malformed checkpoint.")
-    return str(resolved)
+
+    resolved = candidate.resolve()
+    allowed_roots = [base]
+    if base.parent.name == "snapshots":
+        allowed_roots.append(base.parent.parent / "blobs")
+
+    for root in allowed_roots:
+        try:
+            resolved.relative_to(root)
+            break
+        except ValueError:
+            continue
+    else:
+        raise ValueError(
+            f"Shard path {shard!r} in checkpoint index escapes model_dir "
+            f"{model_dir!r}. This may indicate a malformed checkpoint.")
+
+    return str(candidate)
 
 
 def _build_shard_map(model_dir: str) -> Dict[str, str]:

--- a/tests/python-unittests/test_checkpoint_loader_shard.py
+++ b/tests/python-unittests/test_checkpoint_loader_shard.py
@@ -32,13 +32,22 @@ except ImportError as exc:  # pragma: no cover
 
 
 def test_resolve_shard_basename(tmp_path):
-    result = _resolve_shard(str(tmp_path), "model.safetensors")
-    assert result == str(tmp_path / "model.safetensors")
+    shard = tmp_path / "model.safetensors"
+    shard.touch()
+
+    result = _resolve_shard(str(tmp_path), shard.name)
+
+    assert result == str(shard)
 
 
 def test_resolve_shard_subdir_allowed(tmp_path):
+    shard = tmp_path / "subfolder" / "model.safetensors"
+    shard.parent.mkdir()
+    shard.touch()
+
     result = _resolve_shard(str(tmp_path), "subfolder/model.safetensors")
-    assert result == str(tmp_path / "subfolder" / "model.safetensors")
+
+    assert result == str(shard)
 
 
 def test_resolve_shard_traversal_rejected(tmp_path):
@@ -59,3 +68,35 @@ def test_resolve_shard_absolute_path_rejected(tmp_path):
 def test_resolve_shard_returns_str(tmp_path):
     result = _resolve_shard(str(tmp_path), "weights.bin")
     assert isinstance(result, str)
+
+
+@pytest.mark.parametrize(
+    "shard_name",
+    ["model-00001-of-00002.safetensors", "pytorch_model-00001-of-00002.bin"])
+def test_resolve_shard_hugging_face_cache_symlink(tmp_path, shard_name):
+    repository = tmp_path / "models--org--model"
+    snapshot = repository / "snapshots" / "revision"
+    blobs = repository / "blobs"
+    snapshot.mkdir(parents=True)
+    blobs.mkdir()
+
+    blob = blobs / "abcdef123456"
+    blob.touch()
+    shard = snapshot / shard_name
+    shard.symlink_to(os.path.join("..", "..", "blobs", blob.name))
+
+    result = _resolve_shard(str(snapshot), shard_name)
+
+    assert result == str(shard)
+
+
+def test_resolve_shard_external_symlink_rejected(tmp_path):
+    snapshot = tmp_path / "models--org--model" / "snapshots" / "revision"
+    snapshot.mkdir(parents=True)
+    external = tmp_path / "external.safetensors"
+    external.touch()
+    shard = snapshot / "model.safetensors"
+    shard.symlink_to(external)
+
+    with pytest.raises(ValueError, match="escapes model_dir"):
+        _resolve_shard(str(snapshot), shard.name)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixes #184.

Hugging Face Hub stores checkpoint files under `blobs/` and exposes them from model snapshots through symlinks:

```text
models--org--model/
├── blobs/<hash>
└── snapshots/<revision>/
    └── model-00001-of-00002.safetensors -> ../../blobs/<hash>
```

`_resolve_shard()` previously resolved the symlink before checking path containment. The resolved path therefore appeared outside the snapshot directory, causing valid Hugging Face checkpoint shards to be rejected with `ValueError`.

## Changes

- Reject absolute shard names.
- Lexically normalize shard paths with `os.path.abspath()` and reject paths that traverse outside `model_dir`.
- Allow resolved shard targets under:
  - the checkpoint directory; or
  - the repository's `blobs/` directory when `model_dir` follows the standard `snapshots/<revision>` layout.
- Continue rejecting symlinks that resolve outside the approved checkpoint roots.
- Return the snapshot shard path instead of the resolved blob path, preserving the `.bin` and `.safetensors` suffixes used by the loader.
- Add regression coverage for:
  - regular shard files;
  - nested shard paths;
  - Hugging Face snapshot symlinks for `.bin` and `.safetensors` shards;
  - absolute paths and `..` traversal;
  - symlinks pointing to unrelated external locations.

`os.path.abspath()` is used for lexical normalization because `Path.absolute()` preserves `..` components on supported Python versions and could weaken the traversal check.

## Usage

No usage changes are required. Existing Hugging Face model identifiers and snapshot paths continue to work as before.

## Testing

- Focused checkpoint shard tests on Ubuntu with an NVIDIA GeForce RTX 5090:

  ```text
  9 passed
  ```

- `pre-commit run --all-files` passed.
- Python syntax compilation passed for the modified source and test files.
- `git diff --check` passed.

## Not tested

- The full export → build → inference pipeline was not run.

## API and compatibility impact

- No public API changes.
- Backward compatible with regular local checkpoint layouts.
- Symlinks outside the checkpoint directory and approved Hugging Face `blobs/` directory remain rejected.

## Pull Request Checklist

- [x] Tests have been added or updated as needed.
- [x] Relevant tests are passing.
- [x] `pre-commit run --all-files` passes.
- [x] No documentation changes are required.
- [x] The change is backward compatible.

## Additional Information

Fixes #184.