### PR TITLE
fix: Share the target lm_head for DSpark drafts without their own head

### DIFF
--- a/experimental/builder/models/dspark/modeling_dspark_draft.py
+++ b/experimental/builder/models/dspark/modeling_dspark_draft.py
@@ -18,11 +18,13 @@ from typing import Dict
 
 import tensorrt as trt
 
+from ...core import config as core_config
 from ...core import quantization
 from ...ops import (GatedMLP, Linear, Module, NetworkModule, RMSNorm,
                     TreeAttention)
 from ...ops import functional as F
 from ...ops import pack_qkv
+from .. import registry as model_registry
 
 
 class DSparkProposalAttention(TreeAttention):
@@ -112,11 +114,45 @@ class DSparkTargetProjection(Module):
 class DSparkDraftModel(NetworkModule):
     """Parallel proposal backbone with hidden output for sequential heads."""
 
-    def __init__(self, ctx) -> None:
-        super().__init__(ctx)
-        if not (ctx.weights.has("lm_head.weight")
+    @classmethod
+    def from_config(cls, ctx):
+        if (ctx.weights.has("lm_head.weight")
                 or ctx.weights.has("lm_head.qweight")):
-            raise ValueError("DSpark draft checkpoint must provide lm_head")
+            return cls(ctx)
+
+        # Drafts such as RadixArk/Qwen3.8-27B-DSpark ship no head of their own
+        # and share the target model's lm_head, quantized as in the target.
+        args = ctx.args
+        target_cfg = core_config.DeviceConfig.from_pretrained(
+            args.target_model_dir, tp_size=args.tp_size, tp_rank=args.tp_rank)
+        target_bundle = core_config.BundleConfig.from_pretrained(
+            args.target_model_dir)
+        conversion = model_registry.weight_conversion_for(
+            target_bundle.root_model_type)
+        target_weights = ctx.open_weights(
+            args.target_model_dir,
+            group_size=target_cfg.group_size,
+            quant=target_cfg.quant,
+            component="llm",
+            vocab_map=ctx.weights.vocab_map,
+            conversion=conversion,
+            int4_gemm_plugin_version=args.int4_gemm_plugin_version,
+            checkpoint_source="target",
+            tie_word_embeddings=target_cfg.tie_word_embeddings)
+        try:
+            target_context = ctx.with_checkpoint(target_cfg, target_weights)
+            model = cls(ctx,
+                        lm_head=Linear(target_context,
+                                       target_weights.causal_lm_head_prefix()))
+        except Exception:
+            target_weights.close()
+            raise
+        model._target_weights = target_weights
+        return model
+
+    def __init__(self, ctx, lm_head=None) -> None:
+        super().__init__(ctx)
+        self._target_weights = None
         self.fc = DSparkTargetProjection(ctx, "fc")
         self.hidden_norm = RMSNorm(ctx, "hidden_norm", ctx.cfg.rms_norm_eps)
         self.layers = [
@@ -124,7 +160,13 @@ class DSparkDraftModel(NetworkModule):
             for index in range(ctx.cfg.num_hidden_layers)
         ]
         self.norm = RMSNorm(ctx, "norm", ctx.cfg.rms_norm_eps)
-        self.lm_head = Linear(ctx, "lm_head")
+        self.lm_head = lm_head or Linear(ctx, "lm_head")
+
+    def close(self) -> None:
+        if self._target_weights is not None:
+            self._target_weights.close()
+            self._target_weights = None
+        super().close()
 
     def input_tensors(self) -> Dict[str, object]:
         cfg = self.cfg


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix (direct builder, DSpark speculative decoding)

**Overview:**

[RadixArk/Qwen3.8-27B-DSpark](https://huggingface.co/RadixArk/Qwen3.8-27B-DSpark) is listed under *DSpark Draft Models* as the pair for `RadixArk/Qwen3.8-27B-NVFP4`. The draft checkpoint ships five proposal layers and no `lm_head`; it shares the target model's head. The ONNX export path already handles this (`tensorrt_edgellm/models/dspark/modeling_dspark_draft.py` documents `lm_head` as "shared with base"), but the direct builder rejected the checkpoint:

```
ValueError: DSpark draft checkpoint must provide lm_head
```

so `tensorrt-edgellm-serve` could not build the pair.

`DSparkDraftModel` now mirrors `Eagle3DraftModel`: when the draft checkpoint has no head, `from_config` opens the paired target checkpoint (`--target-model-dir`, which the CLI already passes for paired drafts) as a second `Weights` source with `checkpoint_source="target"`, builds `lm_head` from the target's head in the target's precision (NVFP4 here), and releases the target weights in `close()`. Drafts that carry their own head are unchanged.

**Verified** on Jetson AGX Thor with the Qwen3.8-27B NVFP4 (ModelOpt) base and `Qwen3.8-27B-DSpark`, block size 7, batch 4, max input 32768, KV capacity 65536:

- bundle builds (base 9.5 min, draft 11 min, visual 42 s) and serves through `tensorrt-edgellm-serve` with `--speculative-config '{"method":"dspark","model":<draft>,"num_speculative_tokens":7}'`;
- coding prompts decode at 44–57 tok/s single-stream and 128 tok/s aggregate at 4 concurrent requests; `num_speculative_tokens` from 1 to 7 works at runtime;
- image requests keep working alongside DSpark.

## Usage

```bash
tensorrt-edgellm-serve RadixArk/Qwen3.8-27B-NVFP4 \
  --cache-dir /data/edgellm-cache \
  --speculative-config '{"method":"dspark","model":"RadixArk/Qwen3.8-27B-DSpark","num_speculative_tokens":7}'
```

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

### 🧪 Tests

- [x] Tests have been added or updated as needed (no unit test: the change mirrors the existing EAGLE3 target-head path, which has none either; verified end to end as described above).
- [x] All tests are passing.

### 📄 Documentation
- [x] No documentation change needed; the pair is already listed in `supported-models.md`.

### ⚙️ Compatibility
- [x] The change is backward compatible: drafts with their own `lm_head` take the unchanged path.

## Additional Information

Independent of #199; it only touches `experimental/builder/models/dspark/modeling_dspark_draft.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
